### PR TITLE
[OAP-TOOL-96] Using miniconda2 instead of Dataproc default miniconda3…

### DIFF
--- a/integrations/oap/dataproc/benchmark/SQL_DS_Cache_on_Dataproc.md
+++ b/integrations/oap/dataproc/benchmark/SQL_DS_Cache_on_Dataproc.md
@@ -173,6 +173,7 @@ spark.sql.oap.parquet.binary.cache.enabled                   true
 spark.oap.cache.strategy                                     external
 spark.sql.oap.dcpmm.free.wait.threshold                      50000000000
 spark.executor.sql.oap.cache.external.client.pool.size       2
+# cache size 
 spark.executor.sql.oap.cache.persistent.memory.initial.size  50g
 
 spark.executorEnv.LD_LIBRARY_PATH   /opt/benchmark-tools/oap/lib
@@ -184,8 +185,8 @@ spark.driver.extraLibraryPath       /opt/benchmark-tools/oap/lib
 ```
  "launch_command": "{%oap.home%}/bin/plasma-store-server -m {%plasma.cache.size%} -s /tmp/plasmaStore -d <replace-with-cache-storage-path>",
 ```
-For example, replace the <replace-with-cache-storage-path> to disk path `/mnt/1` or PMem path.
-If you put disk path like `/mnt/1` to use as storage path, please chmod its mode of each worker as below, if you are not root user:
+Replace the <replace-with-cache-storage-path> to disk path  or PMem path.
+If you put disk path like `/mnt/1` to use as data **Caching** path when running queries, please change its mode of each worker as below, if you are not root user:
 ```
 sudo -i
 chmod 777 /mnt/1

--- a/integrations/oap/dataproc/bootstrap_oap.sh
+++ b/integrations/oap/dataproc/bootstrap_oap.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 oap_install_dir=/opt/benchmark-tools/oap
-sudo mkdir -p $oap_install_dir
+mkdir -p $oap_install_dir
 conda_install_dir=/opt/benchmark-tools/conda
-sudo chown $(whoami):$(whoami) ${oap_install_dir}
 
-## conda install oap
+
+## Step 1: install conda
+wget -c https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -P /tmp
+chmod +x /tmp/Miniconda2-latest-Linux-x86_64.sh
+bash /tmp/Miniconda2-latest-Linux-x86_64.sh -b -p ${conda_install_dir}
+${conda_install_dir}/bin/conda init
+source ~/.bashrc
+
+## Step 2: conda install oap
 
 conda create -p ${oap_install_dir}  -c conda-forge -c intel-beaver -c intel -c intel-bigdata -y oap=1.2.0.dataproc20
-


### PR DESCRIPTION
… when install OAP packages to avoid confilcts