### PR TITLE
Use the raw file link for bootstrap_oap.sh and bootstrap_benchmark.sh.

### DIFF
--- a/integrations/oap/benchmark-tool/README.md
+++ b/integrations/oap/benchmark-tool/README.md
@@ -6,7 +6,7 @@ This guide helps run different workloads easily on Cloud Platforms. It also prov
 
 ### 1.1 AWS EMR
 
-If you are using AWS EMR, you can refer [OAP integrate EMR](../emr/README.md) to create a new cluster. To run benchmark on EMR cluster with OAP, you also need to upload both **[bootstrap_benchmark.sh](../emr/benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](../emr/bootstrap_oap.sh)** to S3 and add extra bootstrap action to execute **[bootstrap_benchmark.sh](../emr/benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](../emr/bootstrap_oap.sh)** when creating a new cluster.
+If you are using AWS EMR, you can refer [OAP integrate EMR](../emr/README.md) to create a new cluster. To run benchmark on EMR cluster with OAP, you also need to upload both **[bootstrap_benchmark.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** to S3 and add extra bootstrap action to execute **[bootstrap_benchmark.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** when creating a new cluster.
 
 ![upload_init_script and install_benchmark.sh](../emr/imgs/upload_all_scripts_to_S3.PNG)
 
@@ -268,11 +268,11 @@ Please refer to the [Hibench Guide](https://github.com/Intel-bigdata/HiBench) to
 
 ## 7. Run HiBench, TPC-DS, TPC-H with OAP
 
-Please follow [Gazelle_on_EMR.md](../emr/benchmark/Gazelle_on_EMR.md) or [Gazelle_on_Dataproc.md](../dataproc/benchmark/Gazelle_on_Dataproc.md) to run TPC-DS or TPC-H with Gazelle_plugin.
+Please follow [Gazelle on EMR](../emr/benchmark/Gazelle_on_EMR.md) or [Gazelle on Dataproc](../dataproc/benchmark/Gazelle_on_Dataproc.md) to run TPC-DS or TPC-H with Gazelle_plugin.
 
-Please follow [SQL_DS_Cache_on_Dataproc.md](../dataproc/benchmark/SQL_DS_Cache_on_Dataproc.md) to run TPC-DS with SQL DS Cache.
+Please follow [SQL-DS-Cache_on Dataproc](../dataproc/benchmark/SQL_DS_Cache_on_Dataproc.md) to run TPC-DS with SQL DS Cache.
 
-Please follow [Intel_MLlib_on_EMR.md](../emr/benchmark/Intel_MLlib_on_EMR.md) or [OAP_MLlib_on_Dataproc.md](../dataproc/benchmark/OAP_MLlib_on_Dataproc.md)to run K-means, PAC, ALS with OAP MLlib.
+Please follow [Intel MLlib on EMR](../emr/benchmark/Intel_MLlib_on_EMR.md) or [OAP MLlib on Dataproc](../dataproc/benchmark/OAP_MLlib_on_Dataproc.md)to run K-means, PAC, ALS with OAP MLlib.
 
 
 ## 8. Run workflow ##

--- a/integrations/oap/emr/README.md
+++ b/integrations/oap/emr/README.md
@@ -2,10 +2,10 @@
 
 ## 1. Upload init script 
 
-Upload the init script **[bootstrap_oap.sh](./bootstrap_oap.sh)** to S3:
+Upload the init script **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** to S3:
     
-1. Download **[bootstrap_oap.sh](./bootstrap_oap.sh)** to a local folder.
-2. Update **[bootstrap_oap.sh](./bootstrap_oap.sh)** to S3.
+1. Download **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** to a local folder.
+2. Update **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** to S3.
 
 ![upload_init_script and install_benchmark.sh](./imgs/upload_scripts_to_S3.PNG)
 
@@ -16,8 +16,8 @@ To create a new cluster using the uploaded bootstrap script, follow the followin
 1. Click the  **Go to advanced options** to custom your cluster;
 2. **Software and Steps:** choose the release of emr and the software you need;
 3. **Hardware:** choose the instance type and other configurations of hardware;
-4. **General Cluster Settings:** add **[bootstrap_oap.sh](./bootstrap_oap.sh)** (install OAP binary) like following picture
-(Note: the version of OAP channel need to be passed to **[bootstrap_oap.sh](./bootstrap_oap.sh)**; the default version of OAP channel is 1.2.0; 1.2.0.emr630 fits to EMR-6.3.0 environment);
+4. **General Cluster Settings:** add **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** (install OAP binary) like following picture
+(Note: the version of OAP channel need to be passed to **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)**; the default version of OAP channel is 1.2.0; 1.2.0.emr630 fits to EMR-6.3.0 environment);
 ![Add bootstrap action](./imgs/add-bootstrap-oap.PNG)
 5. **Security:** define the permissions and other security configurations;
 6. Click **Create cluster**. 

--- a/integrations/oap/emr/benchmark/Gazelle_on_EMR.md
+++ b/integrations/oap/emr/benchmark/Gazelle_on_EMR.md
@@ -2,7 +2,7 @@
 
 ## 1. Create a new cluster
 
-To run bencbmark on EMR cluster with OAP, you need upload both **[bootstrap_benchmark.sh](../benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](../bootstrap_oap.sh)** to S3 and add extra bootstrap action to execute **[bootstrap_benchmark.sh](../benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](../bootstrap_oap.sh)**when creating a new cluster.
+To run bencbmark on EMR cluster with OAP, you need upload both **[bootstrap_benchmark.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** to S3 and add extra bootstrap action to execute **[bootstrap_benchmark.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** when creating a new cluster.
 
 ![upload_init_script and install_benchmark.sh](../imgs/upload_all_scripts_to_S3.PNG)
 
@@ -38,7 +38,7 @@ BUCKET={bucket_name}
 Note: If you want to use s3 for storage, you must define BUCKET; if you use hdfs for storage, you should set STORAGE like ```STORAGE=hdfs```
 
 #### Update the configurations of spark
-**[bootstrap_oap.sh](../bootstrap_oap.sh)** will help install all OAP packages under dir `/opt/benchmark-tools/oap`,
+**[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** will help install all OAP packages under dir `/opt/benchmark-tools/oap`,
 make sure to add below configuration to `./repo/confs/gazelle_plugin_performance/spark/spark-defaults.conf`.
 
 ```

--- a/integrations/oap/emr/benchmark/Intel_MLlib_on_EMR.md
+++ b/integrations/oap/emr/benchmark/Intel_MLlib_on_EMR.md
@@ -2,7 +2,7 @@
 
 ## 1. Create a new cluster
 
-To run bencbmark on EMR cluster with OAP, you need upload both **[bootstrap_benchmark.sh](../benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](../bootstrap_oap.sh)** to S3 and add extra bootstrap action to execute **[bootstrap_benchmark.sh](../benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](../bootstrap_oap.sh)** when creating a new cluster.
+To run bencbmark on EMR cluster with OAP, you need upload both **[bootstrap_benchmark.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** to S3 and add extra bootstrap action to execute **[bootstrap_benchmark.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/benchmark/bootstrap_benchmark.sh)** and **[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** when creating a new cluster.
 
 ![upload_init_script and install_benchmark.sh](../imgs/upload_all_scripts_to_S3.PNG)
 
@@ -37,7 +37,7 @@ BUCKET={bucket_name}
 Note: If you want to use s3 for storage, you must define BUCKET; if you use hdfs for storage, you should set STORAGE like ```STORAGE=hdfs```
 
 #### Update the configurations of spark
-**[bootstrap_oap.sh](../bootstrap_oap.sh)** will help install all OAP packages under dir `/opt/benchmark-tools/oap`,
+**[bootstrap_oap.sh](https://raw.githubusercontent.com/oap-project/oap-tools/branch-1.2/integrations/oap/emr/bootstrap_oap.sh)** will help install all OAP packages under dir `/opt/benchmark-tools/oap`,
 make sure to add below configuration to `./repo/confs/Intel_MLlib_performance/hibench/spark.conf`.
 
 ```

--- a/integrations/oap/emr/benchmark/bootstrap_benchmark.sh
+++ b/integrations/oap/emr/benchmark/bootstrap_benchmark.sh
@@ -51,13 +51,6 @@ function install_hibench() {
   else
     cd HiBench && git pull
   fi
-  cp hadoopbench/mahout/pom.xml hadoopbench/mahout/pom.xml.bak
-  cat hadoopbench/mahout/pom.xml \
-      | sed 's|<repo2>http://archive.cloudera.com</repo2>|<repo2>https://archive.apache.org</repo2>|' \
-      | sed 's|cdh5/cdh/5/mahout-0.9-cdh5.1.0.tar.gz|dist/mahout/0.9/mahout-distribution-0.9.tar.gz|' \
-      | sed 's|aa953e0353ac104a22d314d15c88d78f|09b999fbee70c9853789ffbd8f28b8a3|' \
-      > ./pom.xml.tmp
-  mv ./pom.xml.tmp hadoopbench/mahout/pom.xml
   mvn -Psparkbench -Dmodules -Pml -Pmicro -Dspark=3.0 -Dscala=2.12 -DskipTests clean package
 }
 


### PR DESCRIPTION
Use the raw file link for bootstrap_oap.sh and bootstrap_benchmark.sh; Remove useless step when installing HiBench.