### PR TITLE
[OAP-TOOLS-221] Modify Dataproc user guide for Gazelle

### DIFF
--- a/docs/Gazelle_on_Dataproc.md
+++ b/docs/Gazelle_on_Dataproc.md
@@ -94,6 +94,7 @@ spark.sql.columnar.codegen.hashAggregate false
 spark.yarn.appMasterEnv.LD_PRELOAD           /usr/lib64/libjemalloc.so
 spark.network.timeout 3600s
 spark.sql.warehouse.dir hdfs:///datagen
+spark.dynamicAllocation.enabled false
 
 ```
 #### Verify Gazelle Plugin Integration

--- a/integrations/oap/dataproc/benchmark/Gazelle_on_Dataproc.md
+++ b/integrations/oap/dataproc/benchmark/Gazelle_on_Dataproc.md
@@ -149,6 +149,7 @@ spark.sql.columnar.codegen.hashAggregate false
 spark.yarn.appMasterEnv.LD_PRELOAD           /usr/lib64/libjemalloc.so
 spark.network.timeout 3600s
 spark.sql.warehouse.dir hdfs:///datagen
+spark.dynamicAllocation.enabled false
 
 ```
 #### Define the configurations of TPC-DS


### PR DESCRIPTION
GCP Dataproc Sparks will enable dynamic allocation by default, we need additionally disable it for TPC-DS performance comparation with Vanilla Spark.